### PR TITLE
Make a shadowJar for releases

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -8,3 +8,5 @@ jobs:
     permissions:
       contents: write
     uses: qupath/actions/.github/workflows/github-release.yml@main
+    with:
+      gradle-args: shadowJar


### PR DESCRIPTION
The current version gives me a classdefnotfound exception, which doesn't seem to happen with this.